### PR TITLE
Timescale toolkit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,7 +89,7 @@ jobs:
           context: .
           pull: true
           push: ${{ github.ref_name == 'main' }}
-          platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on: push
 
 env:
   # renovate datasource=github-releases depName=timescale/timescaledb
-  TIMESCALE_VERSION: 2.16.1
+  TIMESCALE_VERSION: 2.17.1
 
   # renovate datasource=github-releases depName=timescale/timescaledb-toolkit
   TIMESCALE_TOOLKIT_VERSION: 1.18.0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,9 @@ env:
   # renovate datasource=github-releases depName=timescale/timescaledb
   TIMESCALE_VERSION: 2.16.1
 
+  # renovate datasource=github-releases depName=timescale/timescaledb-toolkit
+  TIMESCALE_TOOLKIT_VERSION: 1.18.0
+
 jobs:
   build:
     name: Build Image (pg${{ matrix.postgres_version }})
@@ -47,6 +50,14 @@ jobs:
             echo "minor=$(cut -d. -f-2 <<<"$TIMESCALE_VERSION")"
             echo "major=$(cut -d. -f1 <<<"$TIMESCALE_VERSION")"
           } >> $GITHUB_OUTPUT
+      - name: Get Timescale Toolkit version
+        id: timescale_toolkit
+        run: |
+          {
+            echo "version=$TIMESCALE_TOOLKIT_VERSION"
+            echo "minor=$(cut -d. -f-2 <<<"$TIMESCALE_TOOLKIT_VERSION")"
+            echo "major=$(cut -d. -f1 <<<"$TIMESCALE_TOOLKIT_VERSION")"
+          } >> $GITHUB_OUTPUT
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -85,6 +96,7 @@ jobs:
             POSTGRES_VERSION=${{ matrix.postgres_version }}
             CLOUDNATIVEPG_VERSION=${{ steps.cnpg.outputs.version }}
             TIMESCALE_VERSION=${{ steps.timescale.outputs.version }}
+            TIMESCALE_TOOLKIT_VERSION=${{ steps.timescale_toolkit.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ USER root
 
 ARG POSTGRES_VERSION
 ARG TIMESCALE_VERSION
+ARG TIMESCALE_TOOLKIT_VERSION
 RUN <<EOT
   set -eux
 
@@ -22,6 +23,10 @@ RUN <<EOT
   # Install Timescale
   apt-get update
   apt-get install -y --no-install-recommends "timescaledb-2-postgresql-$POSTGRES_VERSION=$TIMESCALE_VERSION~debian$VERSION_ID"
+
+  # Install Timescale Toolkit
+  apt-get update
+  apt-get install -y --no-install-recommends "timescaledb-toolkit-postgresql-$POSTGRES_VERSION=$TIMESCALE_TOOLKIT_VERSION~debian$VERSION_ID"
 
   # Cleanup
   apt-get purge -y curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN <<EOT
 
   # Install Timescale Toolkit
   apt-get update
-  apt-get install -y --no-install-recommends "timescaledb-toolkit-postgresql-$POSTGRES_VERSION=$TIMESCALE_TOOLKIT_VERSION~debian$VERSION_ID"
+  apt-get install -y --no-install-recommends "timescaledb-toolkit-postgresql-$POSTGRES_VERSION=1:$TIMESCALE_TOOLKIT_VERSION~debian$VERSION_ID"
 
   # Cleanup
   apt-get purge -y curl


### PR DESCRIPTION
I've slightly edited @Sh1ken PR, now timescaledb toolkit installs correctly.

But we need to drop ARM support, they don't have a package for ARM.

Also, I've asked timescaledb slack channel if we allowed to distribute their image this way. While this repository does not violate their BUSL license, docker image with timescaledb preinstalled can violate it. That's why I need more clarification on that